### PR TITLE
Output to console.log instead of console.error

### DIFF
--- a/01-buffer-vs-stream/buffer-copy-profile.js
+++ b/01-buffer-vs-stream/buffer-copy-profile.js
@@ -6,7 +6,7 @@ import {
 const start = performance.now()
 
 const profile = setInterval(() => {
-  console.error(`${(process.memoryUsage().arrayBuffers / 1024 / 1024).toFixed(4).padStart(10)} Mb`)
+  console.log(`${(process.memoryUsage().arrayBuffers / 1024 / 1024).toFixed(4).padStart(10)} Mb`)
 }, 100)
 
 async function copyFile (src, dest) {


### PR DESCRIPTION
A small typo fix.

Is there a specific reason to display the output on the error console? I think it's better to display the output on the log console.